### PR TITLE
رفع مشکل در دستور نصب Karma

### DIFF
--- a/Projects/Frontend/PhaseF07-UnitTest/PhaseF07-UnitTest.md
+++ b/Projects/Frontend/PhaseF07-UnitTest/PhaseF07-UnitTest.md
@@ -129,7 +129,7 @@
     <div dir="ltr">
 
     ```
-    npm install karma@latest –save-dev
+    npm install karma@latest -–save-dev
     ```
 
     </div>


### PR DESCRIPTION
در دستور نصب Karma از –save-dev به جای -–save-dev به اشتباه استفاده شده است که سبب می‌شود این دستور پس از اجرا، کار نکند.